### PR TITLE
Add message for failed authentication

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1,6 +1,7 @@
 class SessionController < ApplicationController
 
   def new
+    @failed_auth = false
   end
 
   def create
@@ -11,6 +12,7 @@ class SessionController < ApplicationController
       session[:user_id] = user.id
       redirect_to("/")
     else
+      @failed_auth = true
       render(:new)
     end
   end

--- a/app/views/session/new.html.erb
+++ b/app/views/session/new.html.erb
@@ -1,3 +1,7 @@
+<% if @failed_auth %>
+  <h2>Invalid user name or password!!</h2>
+<% end %>
+
 <%= form_tag("/session", method: "post") do %>
   <%= label_tag(:email) %>
   <%= text_field_tag(:email) %>


### PR DESCRIPTION
Adds a conditional message to the session view
which warns the user that the attempted login
failed.

This will make it easier to notice when the database got reset and you keep failing to log in.
