### PR TITLE
Add HouseMaintenance module

### DIFF
--- a/app/controllers/houses_controller.rb
+++ b/app/controllers/houses_controller.rb
@@ -43,7 +43,11 @@ class HousesController < ApplicationController
 
   def destroy
     house = House.find_by({id: params[:id]})
-    house.delete
+    delete_it = HouseMaintenance.PrepareForHouseDeletion(house)
+    if delete_it
+      house.delete
+    end
+
     redirect_to("/houses")
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
 
     if @user.save
-      House.create({region_id: 9, name: "No House",
+      House.create({region_id: 9, name: HouseMaintenance.DefaultHouseName(),
                     history: "This house was created for you upon account creation.",
                     user_id: @user.id})
       redirect_to("/")

--- a/app/models/house_maintenance.rb
+++ b/app/models/house_maintenance.rb
@@ -1,0 +1,39 @@
+module HouseMaintenance
+
+  DEFAULT_HOUSE_NAME = "No House"
+  def self.DefaultHouseName
+    return DEFAULT_HOUSE_NAME
+  end
+
+  # Moves all characters from the house being
+  # deleted to the default house.
+  #
+  # params:
+  #   house - The House to delete
+  # returns false if the default house is
+  #   attempting to be deleted
+  def self.PrepareForHouseDeletion(house)
+    house_to_delete = nil
+    if house.class == House
+      house_to_delete = house
+    elsif house.class == House.id
+      house_to_delete = House.find_by({id: house})
+    end
+
+    if house_to_delete == nil
+      return false
+    else
+      no_house = House.find_by(name: DEFAULT_HOUSE_NAME, user_id: house_to_delete.user_id)
+      if (house_to_delete.id == no_house.id) || (no_house == nil)
+        return false
+      end
+
+      house_to_delete.characters.each do |c|
+        c.house = no_house
+        c.save
+      end
+    end
+
+    return true
+  end
+end


### PR DESCRIPTION
Adds a new module to do house maintenance.

Currently keeps the default house name and will move
characters to that default house if the house it
belongs to is deleted.

Makes sure that the default house is not deleted as well.

---

Tested that "No House" is still created upon user creation.
Tested that "No House" cannot be deleted by the user (the button still exists, but it will now just leave the house alone and will be shown in the houses list when going back to that view)
Tested that when a house with characters is deleted, those characters are still visible in the characters view and that they are assigned to the "No House" default house.
