### PR TITLE
Order houses by create_time

### DIFF
--- a/app/controllers/houses_controller.rb
+++ b/app/controllers/houses_controller.rb
@@ -1,8 +1,7 @@
 class HousesController < ApplicationController
 
   def index
-    # FIXME Correct so it lists houses in order of creation, not when they were updated
-    @houses = current_user.houses
+    @houses = current_user.houses.order(:created_at)
   end
 
   def new


### PR DESCRIPTION
By default, houses will be ordered by edit time in the
Houses view. This will order them by creation time instead.
