### PR TITLE
Fixes the labels for the abilities in char edit

### DIFF
--- a/app/views/characters/edit.html.erb
+++ b/app/views/characters/edit.html.erb
@@ -15,7 +15,7 @@
   <ul>
     <%= f.fields_for :abilities do |abil| %>
     <li>
-      <%= abil.label(:rank_id) %>
+      <%= abil.label(:ability_name_id, abil.object.ability_name.name) %>
       <%= abil.hidden_field(:id) %>
       <%= abil.number_field(:rank) %>
     </li>


### PR DESCRIPTION
Uses abil.object to get at the actual Abilities object being
referenced in the field_for loop; and passes the
actual name of the ability as the text to use for the label
