### PR TITLE
Stop using hard-coded region id for default house

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,8 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
 
     if @user.save
-      House.create({region_id: 9, name: HouseMaintenance.DefaultHouseName(),
+      House.create({region_id: HouseMaintenance.DefaultHouseRegionId(),
+                    name: HouseMaintenance.DefaultHouseName(),
                     history: "This house was created for you upon account creation.",
                     user_id: @user.id})
       redirect_to("/")

--- a/app/models/house_maintenance.rb
+++ b/app/models/house_maintenance.rb
@@ -5,6 +5,11 @@ module HouseMaintenance
     return DEFAULT_HOUSE_NAME
   end
 
+  DEFAULT_REGION_NAME = "The Seven Kingdoms"
+  def self.DefaultHouseRegionId
+    return Region.find_by({name: DEFAULT_REGION_NAME}).id;
+  end
+
   # Checks if the given house is the default house
   #
   # params:


### PR DESCRIPTION
Instead of assuming the region_id for creation of "No House" per
user, the code will now look up the region_id based on the region
name of "The Seven Kingdoms". The name will stick around after a
database seed; but the id will change.
