### PR TITLE
Update dependencies for working with Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
+gem 'tzinfo-data'
+
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
@@ -24,7 +26,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 # Use ActiveModel has_secure_password
-gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '3.1.10'
 
 # Use Unicorn as the app server
 # gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       activerecord (>= 2.3.0)
       rake (>= 0.8.7)
     arel (6.0.0)
-    bcrypt (3.1.7)
+    bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -89,11 +89,19 @@ GEM
     multi_json (1.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    nokogiri (1.6.6.2-x86-mingw32)
+      mini_portile (~> 0.6.0)
     pg (0.18.1)
+    pg (0.18.1-x86-mingw32)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry (0.10.1-x86-mingw32)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      win32console (~> 1.3)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     rack (1.6.0)
@@ -175,6 +183,8 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2015.7)
+      tzinfo (>= 1.0.0)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -183,15 +193,18 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    win32console (1.3.2-x86-mingw32)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    yaml (4.2.2)
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   annotate
-  bcrypt (~> 3.1.7)
+  bcrypt (= 3.1.10)
   byebug
   capybara
   coffee-rails (~> 4.1.0)
@@ -208,5 +221,10 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   spring (~> 1.3.6)
   turbolinks
+  tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  yaml
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,6 @@ GEM
     win32console (1.3.2-x86-mingw32)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    yaml (4.2.2)
 
 PLATFORMS
   ruby
@@ -224,7 +223,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-  yaml
 
 BUNDLED WITH
    1.10.6


### PR DESCRIPTION
Updates bcrypt dependency to 3.1.10
Adds tzinfo dependency

With these modifications, the app can be made to work with
Ruby 2.1 on Windows (not Ruby 2.2 as of this writing).
