### PR TITLE
List Character Abilities with sort in edit

### DIFF
--- a/app/views/characters/edit.html.erb
+++ b/app/views/characters/edit.html.erb
@@ -13,7 +13,7 @@
   <%= f.text_area(:history, size: "60x12") %>
   Abilities
   <ul>
-    <%= f.fields_for :abilities do |abil| %>
+    <%= f.fields_for :abilities, @character.abilities.sort do |abil| %>
     <li>
       <%= abil.label(:ability_name_id, abil.object.ability_name.name) %>
       <%= abil.hidden_field(:id) %>


### PR DESCRIPTION
Makes it so the character abilites are sorted in the edit
page as well as the view page (in the same order using sort)

Completes fixing Issue #17
